### PR TITLE
Removed crip edges from plot axes so they don't disappear sometimes o…

### DIFF
--- a/src/Plot/Axis.elm
+++ b/src/Plot/Axis.elm
@@ -35,7 +35,6 @@ create scale orient =
         defaultLineAttrs =
             [ fill "none"
             , stroke "#000"
-            , shapeRendering "crispEdges"
             ]
     in
         { scale = scale


### PR DESCRIPTION
…n zoom

Chrome and firefox both have a bug where shape rendering of crisp edges sometimes causes lines to not  render. https://bugzilla.mozilla.org/show_bug.cgi?id=340077
