### PR TITLE
[AR-4343] Reformat with elm-format-0.18 0.7.0-exp

### DIFF
--- a/examples/BarChart.elm
+++ b/examples/BarChart.elm
@@ -1,12 +1,11 @@
 module BarChart exposing (..)
 
-import Svg exposing (Svg, text, text_)
 import Plot exposing (..)
-import Plot.Scale as Scale
 import Plot.Axis as Axis
-import Svg.Attributes exposing (fill, x, y)
-import Plot.Scale exposing (LinearScale, OrdinalScale)
+import Plot.Scale as Scale exposing (LinearScale, OrdinalScale)
 import Plot.SymbolCreator exposing (SymbolCreator)
+import Svg exposing (Svg, text, text_)
+import Svg.Attributes exposing (fill, x, y)
 
 
 main : Svg msg

--- a/examples/Symbols.elm
+++ b/examples/Symbols.elm
@@ -1,17 +1,16 @@
 module Symbols exposing (..)
 
-import Svg exposing (Svg)
-import Svg.Attributes exposing (fill)
-import Plot exposing (..)
-import Plot.Scale as Scale
-import Plot.Axis as Axis
-import Plot.Scale exposing (LinearScale)
-import Plot.Symbols exposing (circle, square, diamond, triangleUp, triangleDown, cross)
-import Plot.SymbolCreator exposing (SymbolCreator)
-import Html exposing (Html, select, option, text, div)
-import Html.Attributes exposing (class, value, selected, style)
+import Html exposing (Html, div, option, select, text)
+import Html.Attributes exposing (class, selected, style, value)
 import Html.Events exposing (on, targetValue)
 import Json.Decode as Json
+import Plot exposing (..)
+import Plot.Axis as Axis
+import Plot.Scale as Scale exposing (LinearScale)
+import Plot.SymbolCreator exposing (SymbolCreator)
+import Plot.Symbols exposing (circle, cross, diamond, square, triangleDown, triangleUp)
+import Svg exposing (Svg)
+import Svg.Attributes exposing (fill)
 
 
 type alias Model =
@@ -125,7 +124,7 @@ options =
             , ( "cross", False )
             ]
     in
-        List.map mkOption opts
+    List.map mkOption opts
 
 
 mkOption : ( String, Bool ) -> Html Msg

--- a/src/Plot.elm
+++ b/src/Plot.elm
@@ -1,29 +1,29 @@
 module Plot
     exposing
-        ( createPlot
-        , addTitle
-        , addAttributes
-        , margins
-        , addSymbols
-        , addVerticalBars
-        , addHorizontalBars
+        ( addAttributes
         , addAxis
+        , addHorizontalBars
+        , addSymbols
+        , addTitle
+        , addVerticalBars
+        , createPlot
+        , margins
         , toSvg
         )
 
-import Svg exposing (svg, Svg)
-import Private.Extras.SvgAttributes exposing (width, height)
-import Private.Dimensions exposing (Dimensions)
-import Private.Margins as Margins exposing (Margins)
-import Private.BoundingBox as BoundingBox exposing (BoundingBox)
-import Private.Scale.Utils as Scale
-import Private.Scale exposing (Scale)
 import Plot.Axis as Axis exposing (Axis)
-import Private.Bars as Bars exposing (Orient)
-import Private.Axis.View as AxisView
-import Private.Title as Title
-import Private.Points as Points
 import Plot.SymbolCreator exposing (SymbolCreator)
+import Private.Axis.View as AxisView
+import Private.Bars as Bars exposing (Orient)
+import Private.BoundingBox as BoundingBox exposing (BoundingBox)
+import Private.Dimensions exposing (Dimensions)
+import Private.Extras.SvgAttributes exposing (height, width)
+import Private.Margins as Margins exposing (Margins)
+import Private.Points as Points
+import Private.Scale exposing (Scale)
+import Private.Scale.Utils as Scale
+import Private.Title as Title
+import Svg exposing (Svg, svg)
 
 
 type alias Plot msg =
@@ -79,7 +79,7 @@ addSymbols points xScale yScale pointToSvg plot =
                 Points.interpolate xScale yScale points
                     |> Points.toSvg pointToSvg
     in
-        addSvgWithTwoScales toSvg xScale yScale plot
+    addSvgWithTwoScales toSvg xScale yScale plot
 
 
 addVerticalBars : Points a b msg -> Scale x a -> Scale y b -> Plot msg -> Plot msg
@@ -110,9 +110,9 @@ addAxis axis plot =
                             , boundingBox = bBox
                         }
                 in
-                    [ AxisView.toSvg a ]
+                [ AxisView.toSvg a ]
     in
-        addSvg svg plot
+    addSvg svg plot
 
 
 toSvg : Plot msg -> Svg msg
@@ -130,7 +130,7 @@ toSvg plot =
             else
                 plotElements ++ [ Title.toSvg plot.title bBox ]
     in
-        svg plot.attrs (svgs)
+    svg plot.attrs svgs
 
 
 addBars : Points a b msg -> Scale x a -> Scale y b -> Bars.Orient -> Plot msg -> Plot msg
@@ -141,7 +141,7 @@ addBars points xScale yScale orient plot =
                 Bars.interpolate xScale yScale points
                     |> Bars.toSvg bBox orient
     in
-        addSvgWithTwoScales createBar xScale yScale plot
+    addSvgWithTwoScales createBar xScale yScale plot
 
 
 addSvgWithTwoScales : (BoundingBox -> Scale a b -> Scale c d -> List (Svg msg)) -> Scale a b -> Scale c d -> Plot msg -> Plot msg
@@ -151,7 +151,7 @@ addSvgWithTwoScales createSvg xScale yScale plot =
             \bBox ->
                 createSvg bBox (Scale.rescaleX bBox xScale) (Scale.rescaleY bBox yScale)
     in
-        addSvg toSvgWithScales plot
+    addSvg toSvgWithScales plot
 
 
 addSvg : (BoundingBox -> List (Svg msg)) -> Plot msg -> Plot msg

--- a/src/Plot/Axis.elm
+++ b/src/Plot/Axis.elm
@@ -1,9 +1,9 @@
 module Plot.Axis exposing (..)
 
+import Private.BoundingBox as BoundingBox exposing (BoundingBox)
 import Private.Scale exposing (Scale)
 import Svg
-import Svg.Attributes exposing (fill, stroke, shapeRendering)
-import Private.BoundingBox as BoundingBox exposing (BoundingBox)
+import Svg.Attributes exposing (fill, shapeRendering, stroke)
 
 
 type Orient
@@ -37,19 +37,19 @@ create scale orient =
             , stroke "#000"
             ]
     in
-        { scale = scale
-        , orient = orient
-        , boundingBox = BoundingBox.init
-        , innerTickSize = 6
-        , outerTickSize = 6
-        , tickPadding = 3
-        , labelRotation = 0
-        , axisAttributes = defaultLineAttrs
-        , innerTickAttributes = defaultLineAttrs
-        , title = Nothing
-        , titleOffset = Nothing
-        , titleAttributes = []
-        }
+    { scale = scale
+    , orient = orient
+    , boundingBox = BoundingBox.init
+    , innerTickSize = 6
+    , outerTickSize = 6
+    , tickPadding = 3
+    , labelRotation = 0
+    , axisAttributes = defaultLineAttrs
+    , innerTickAttributes = defaultLineAttrs
+    , title = Nothing
+    , titleOffset = Nothing
+    , titleAttributes = []
+    }
 
 
 innerTickSize : Int -> Axis a b msg -> Axis a b msg

--- a/src/Plot/Interpolation.elm
+++ b/src/Plot/Interpolation.elm
@@ -13,10 +13,10 @@ linear points =
         pointStrings =
             List.map (\p -> toString p.x ++ "," ++ toString p.y) points
     in
-        if List.length points == 1 then
-            join pointStrings ++ "Z"
-        else
-            join (List.intersperse "L" pointStrings)
+    if List.length points == 1 then
+        join pointStrings ++ "Z"
+    else
+        join (List.intersperse "L" pointStrings)
 
 
 join : List String -> String

--- a/src/Plot/Scale.elm
+++ b/src/Plot/Scale.elm
@@ -1,9 +1,9 @@
 module Plot.Scale exposing (..)
 
-import Private.Scale.Linear as LinearScaleMethods
-import Private.Scale.OrdinalBands as OrdinalBands
 import Private.Extras.Interval as Interval exposing (Interval)
 import Private.Scale exposing (Scale)
+import Private.Scale.Linear as LinearScaleMethods
+import Private.Scale.OrdinalBands as OrdinalBands
 
 
 type alias LinearScale =
@@ -31,10 +31,10 @@ ordinalBands domain range padding outerPadding =
         mapping =
             OrdinalBands.createMapping padding outerPadding
     in
-        { domain = domain
-        , range = Interval.createFromTuple range
-        , interpolate = OrdinalBands.interpolate mapping
-        , uninterpolate = OrdinalBands.uninterpolate mapping
-        , createTicks = OrdinalBands.createTicks mapping
-        , inDomain = OrdinalBands.inDomain
-        }
+    { domain = domain
+    , range = Interval.createFromTuple range
+    , interpolate = OrdinalBands.interpolate mapping
+    , uninterpolate = OrdinalBands.uninterpolate mapping
+    , createTicks = OrdinalBands.createTicks mapping
+    , inDomain = OrdinalBands.inDomain
+    }

--- a/src/Plot/Symbols.elm
+++ b/src/Plot/Symbols.elm
@@ -1,12 +1,12 @@
-module Plot.Symbols exposing (circle, square, diamond, triangleUp, triangleDown, cross)
+module Plot.Symbols exposing (circle, cross, diamond, square, triangleDown, triangleUp)
 
-import Svg exposing (Svg, g, line)
-import Svg.Attributes exposing (d, stroke, strokeWidth)
 import Plot.Interpolation exposing (linear)
+import Plot.SymbolCreator exposing (SymbolCreator)
+import Private.Extras.SvgAttributes exposing (cx, cy, height, r, rotate, width, x, x1, x2, y, y1, y2)
 import Private.Point as Point
 import Private.Points exposing (Points)
-import Private.Extras.SvgAttributes exposing (rotate, cx, cy, r, x, y, width, height, x1, x2, y1, y2)
-import Plot.SymbolCreator exposing (SymbolCreator)
+import Svg exposing (Svg, g, line)
+import Svg.Attributes exposing (d, stroke, strokeWidth)
 
 
 circle : Int -> SymbolCreator a b msg
@@ -34,9 +34,9 @@ diamond : Float -> SymbolCreator a b msg
 diamond length xPos yPos origX origY additionalAttrs =
     let
         attrs =
-            (rotate ( xPos, yPos ) 45) :: additionalAttrs
+            rotate ( xPos, yPos ) 45 :: additionalAttrs
     in
-        square length xPos yPos origX origY attrs
+    square length xPos yPos origX origY attrs
 
 
 triangleUp : Float -> SymbolCreator a b msg
@@ -61,28 +61,28 @@ cross : Float -> SymbolCreator a b msg
 cross length xPos yPos origX origY additionalAttrs =
     let
         attrs =
-            (stroke "black") :: additionalAttrs
+            stroke "black" :: additionalAttrs
     in
-        g []
-            [ line
-                ([ x1 (xPos - length / 2)
-                 , y1 (yPos - length / 2)
-                 , x2 (xPos + length / 2)
-                 , y2 (yPos + length / 2)
-                 ]
-                    ++ attrs
-                )
-                []
-            , line
-                ([ x1 (xPos - length / 2)
-                 , y1 (yPos + length / 2)
-                 , x2 (xPos + length / 2)
-                 , y2 (yPos - length / 2)
-                 ]
-                    ++ attrs
-                )
-                []
-            ]
+    g []
+        [ line
+            ([ x1 (xPos - length / 2)
+             , y1 (yPos - length / 2)
+             , x2 (xPos + length / 2)
+             , y2 (yPos + length / 2)
+             ]
+                ++ attrs
+            )
+            []
+        , line
+            ([ x1 (xPos - length / 2)
+             , y1 (yPos + length / 2)
+             , x2 (xPos + length / 2)
+             , y2 (yPos - length / 2)
+             ]
+                ++ attrs
+            )
+            []
+        ]
 
 
 pathSvg : List (Svg.Attribute msg) -> Points Float Float msg -> Svg msg

--- a/src/Private/Axis/Ticks.elm
+++ b/src/Private/Axis/Ticks.elm
@@ -1,12 +1,12 @@
 module Private.Axis.Ticks exposing (..)
 
-import Plot.Axis as Axis exposing (Orient, Axis)
-import Private.Tick exposing (Tick)
-import Private.Scale.Utils as Scale
+import Plot.Axis as Axis exposing (Axis, Orient)
+import Private.Extras.SvgAttributes exposing (rotate, translate, x, x2, y, y2)
 import Private.Scale exposing (Scale)
-import Svg exposing (Svg, path, text_, g, line)
+import Private.Scale.Utils as Scale
+import Private.Tick exposing (Tick)
+import Svg exposing (Svg, g, line, path, text_)
 import Svg.Attributes exposing (dy, textAnchor)
-import Private.Extras.SvgAttributes exposing (translate, rotate, y2, x2, x, y)
 
 
 type alias TickInfo =
@@ -23,7 +23,7 @@ createTicks axis =
 createTick : Axis a b msg -> TickInfo -> Svg msg
 createTick axis tickInfo =
     g [ translate tickInfo.translation ]
-        [ line ((innerTickLineAttributes axis.orient axis.innerTickSize) ++ axis.innerTickAttributes) []
+        [ line (innerTickLineAttributes axis.orient axis.innerTickSize ++ axis.innerTickAttributes) []
         , text_ (labelAttributes axis.orient axis.innerTickSize axis.tickPadding axis.labelRotation)
             [ Svg.text tickInfo.label ]
         ]
@@ -56,10 +56,10 @@ labelAttributes orient tickSize tickPadding rotation =
                 Axis.Right ->
                     [ dy ".32em", textAnchor "start" ]
     in
-        if rotation == 0 then
-            posAttrs ++ anchorAttrs
-        else
-            posAttrs ++ anchorAttrs ++ [ rotate pos rotation ]
+    if rotation == 0 then
+        posAttrs ++ anchorAttrs
+    else
+        posAttrs ++ anchorAttrs ++ [ rotate pos rotation ]
 
 
 innerTickLineAttributes : Orient -> Int -> List (Svg.Attribute msg)
@@ -68,7 +68,7 @@ innerTickLineAttributes orient tickSize =
         pos =
             innerTickLinePos orient tickSize
     in
-        [ x2 (Tuple.first pos), y2 (Tuple.second pos) ]
+    [ x2 (Tuple.first pos), y2 (Tuple.second pos) ]
 
 
 innerTickLinePos : Orient -> Int -> ( Int, Int )
@@ -101,4 +101,4 @@ createTickInfo scale orient tick =
             else
                 ( 0, tick.position )
     in
-        { label = tick.label, translation = translation }
+    { label = tick.label, translation = translation }

--- a/src/Private/Axis/Title.elm
+++ b/src/Private/Axis/Title.elm
@@ -1,10 +1,10 @@
 module Private.Axis.Title exposing (..)
 
-import Svg exposing (Svg, text, text_)
-import Svg.Attributes exposing (textAnchor)
 import Plot.Axis as Axis exposing (Orient)
 import Private.Extras.Interval exposing (Interval)
 import Private.Extras.SvgAttributes exposing (rotate, x, y)
+import Svg exposing (Svg, text, text_)
+import Svg.Attributes exposing (textAnchor)
 
 
 createTitle : Interval -> Orient -> Int -> Int -> List (Svg.Attribute msg) -> Maybe Int -> Maybe String -> List (Svg msg)
@@ -49,4 +49,4 @@ titleAttrs extent orient innerTickSize tickPadding attrs offset =
             else
                 [ x calOffset, y middle, rotate ( calOffset, middle ) (sign * 90) ]
     in
-        (textAnchor "middle") :: posAttrs ++ attrs
+    textAnchor "middle" :: posAttrs ++ attrs

--- a/src/Private/Axis/View.elm
+++ b/src/Private/Axis/View.elm
@@ -1,14 +1,14 @@
 module Private.Axis.View exposing (..)
 
-import Private.BoundingBox exposing (BoundingBox)
 import Plot.Axis as Axis exposing (Axis, Orient)
+import Private.Axis.Ticks as AxisTicks
+import Private.Axis.Title as AxisTitle
+import Private.BoundingBox exposing (BoundingBox)
+import Private.Extras.Interval as Interval exposing (Interval)
+import Private.Extras.SvgAttributes exposing (translate)
 import Private.Scale exposing (Scale)
 import Svg exposing (Svg, g, path)
 import Svg.Attributes exposing (d)
-import Private.Extras.Interval as Interval exposing (Interval)
-import Private.Extras.SvgAttributes exposing (translate)
-import Private.Axis.Ticks as AxisTicks
-import Private.Axis.Title as AxisTitle
 
 
 toSvg : Axis a b msg -> Svg msg
@@ -17,12 +17,12 @@ toSvg axis =
         extent =
             calculateAxisExtent axis.boundingBox axis.orient axis.scale.range
     in
-        g [ axisTranslation axis.boundingBox axis.orient ] <|
-            List.concat
-                [ [ axisSvg axis ]
-                , AxisTicks.createTicks axis
-                , AxisTitle.createTitle extent axis.orient axis.innerTickSize axis.tickPadding axis.titleAttributes axis.titleOffset axis.title
-                ]
+    g [ axisTranslation axis.boundingBox axis.orient ] <|
+        List.concat
+            [ [ axisSvg axis ]
+            , AxisTicks.createTicks axis
+            , AxisTitle.createTitle extent axis.orient axis.innerTickSize axis.tickPadding axis.titleAttributes axis.titleOffset axis.title
+            ]
 
 
 calculateAxisExtent : BoundingBox -> Orient -> Interval -> Interval
@@ -37,7 +37,7 @@ calculateAxisExtent bBox orient interval =
             else
                 Interval.create (max extent.start bBox.yStart) (min extent.end bBox.yEnd)
     in
-        Interval.extentOf (calc)
+    Interval.extentOf calc
 
 
 axisTranslation : BoundingBox -> Orient -> Svg.Attribute msg
@@ -57,7 +57,7 @@ axisTranslation bBox orient =
                 Axis.Right ->
                     ( bBox.xEnd, 0 )
     in
-        translate pos
+    translate pos
 
 
 axisSvg : Axis a b msg -> Svg msg
@@ -67,10 +67,10 @@ axisSvg axis =
             pathString axis.boundingBox axis.scale axis.orient axis.outerTickSize
 
         attrs =
-            (d ps) :: axis.axisAttributes
+            d ps :: axis.axisAttributes
     in
-        path attrs
-            []
+    path attrs
+        []
 
 
 pathString : BoundingBox -> Scale a b -> Orient -> Int -> String
@@ -99,7 +99,7 @@ pathString bBox scale orient tickSize =
                 Axis.Right ->
                     horizontalAxisString bBox tickSize start end
     in
-        "M" ++ path
+    "M" ++ path
 
 
 verticalAxisString : BoundingBox -> Int -> Float -> Float -> String
@@ -111,7 +111,7 @@ verticalAxisString bBox tickLocation xStart xEnd =
         end =
             min xEnd bBox.xEnd
     in
-        (toString start) ++ "," ++ (toString tickLocation) ++ "V0H" ++ (toString end) ++ "V" ++ (toString tickLocation)
+    toString start ++ "," ++ toString tickLocation ++ "V0H" ++ toString end ++ "V" ++ toString tickLocation
 
 
 horizontalAxisString : BoundingBox -> Int -> Float -> Float -> String
@@ -123,4 +123,4 @@ horizontalAxisString bBox tickLocation yStart yEnd =
         end =
             min yEnd bBox.yEnd
     in
-        (toString tickLocation) ++ "," ++ (toString start) ++ "H0V" ++ (toString end) ++ "H" ++ (toString tickLocation)
+    toString tickLocation ++ "," ++ toString start ++ "H0V" ++ toString end ++ "H" ++ toString tickLocation

--- a/src/Private/Bars.elm
+++ b/src/Private/Bars.elm
@@ -1,11 +1,11 @@
 module Private.Bars exposing (..)
 
-import Private.Point as Point exposing (Point, InterpolatedPoint)
 import Private.BoundingBox exposing (BoundingBox)
-import Svg exposing (Svg, rect)
-import Private.Scale exposing (Scale)
-import Private.Extras.SvgAttributes exposing (x, y, height, width)
+import Private.Extras.SvgAttributes exposing (height, width, x, y)
+import Private.Point as Point exposing (InterpolatedPoint, Point)
 import Private.Points as Points exposing (InterpolatedPoints)
+import Private.Scale exposing (Scale)
+import Svg exposing (Svg, rect)
 
 
 type Orient
@@ -39,12 +39,12 @@ barAttrs bBox orient point =
         pos =
             posInfo bBox orient point
     in
-        [ x pos.x
-        , y pos.y
-        , width pos.width
-        , height pos.height
-        ]
-            ++ point.attrs
+    [ x pos.x
+    , y pos.y
+    , width pos.width
+    , height pos.height
+    ]
+        ++ point.attrs
 
 
 posInfo : BoundingBox -> Orient -> InterpolatedPoint a b msg -> PosInfo

--- a/src/Private/BoundingBox.elm
+++ b/src/Private/BoundingBox.elm
@@ -1,7 +1,7 @@
 module Private.BoundingBox exposing (..)
 
-import Private.Margins exposing (Margins)
 import Private.Dimensions exposing (Dimensions)
+import Private.Margins exposing (Margins)
 
 
 type alias BoundingBox =
@@ -35,9 +35,9 @@ from dim marg =
                 marg.top
                 (dim.height - marg.bottom)
     in
-        if bBox.xStart > bBox.xEnd then
-            init
-        else if bBox.yStart > bBox.yEnd then
-            init
-        else
-            bBox
+    if bBox.xStart > bBox.xEnd then
+        init
+    else if bBox.yStart > bBox.yEnd then
+        init
+    else
+        bBox

--- a/src/Private/Extras/SvgAttributes.elm
+++ b/src/Private/Extras/SvgAttributes.elm
@@ -6,12 +6,12 @@ import Svg.Attributes exposing (transform)
 
 translate : ( number, number ) -> Svg.Attribute msg
 translate pos =
-    transform <| "translate(" ++ (toString (Tuple.first pos)) ++ "," ++ (toString (Tuple.second pos)) ++ ")"
+    transform <| "translate(" ++ toString (Tuple.first pos) ++ "," ++ toString (Tuple.second pos) ++ ")"
 
 
 rotate : ( number, number ) -> Int -> Svg.Attribute msg
 rotate pos rotation =
-    transform <| "rotate(" ++ (toString rotation) ++ "," ++ (toString (Tuple.first pos)) ++ "," ++ (toString (Tuple.second pos)) ++ ")"
+    transform <| "rotate(" ++ toString rotation ++ "," ++ toString (Tuple.first pos) ++ "," ++ toString (Tuple.second pos) ++ ")"
 
 
 x1 : number -> Svg.Attribute msg

--- a/src/Private/Point.elm
+++ b/src/Private/Point.elm
@@ -1,8 +1,8 @@
 module Private.Point exposing (..)
 
-import Private.Scale.Utils as Scale
-import Private.Scale exposing (Scale)
 import Private.PointValue exposing (PointValue)
+import Private.Scale exposing (Scale)
+import Private.Scale.Utils as Scale
 import Svg
 
 

--- a/src/Private/Points.elm
+++ b/src/Private/Points.elm
@@ -1,8 +1,8 @@
-module Private.Points exposing (Points, InterpolatedPoints, interpolate, toSvg)
+module Private.Points exposing (InterpolatedPoints, Points, interpolate, toSvg)
 
-import Private.Scale.Utils as Scale
-import Private.Scale exposing (Scale)
 import Private.Point as Point exposing (InterpolatedPoint, Point)
+import Private.Scale exposing (Scale)
+import Private.Scale.Utils as Scale
 import Svg exposing (Svg, rect)
 
 

--- a/src/Private/Scale.elm
+++ b/src/Private/Scale.elm
@@ -1,8 +1,8 @@
 module Private.Scale exposing (..)
 
 import Private.Extras.Interval as Interval exposing (Interval)
-import Private.Tick exposing (Tick)
 import Private.PointValue exposing (PointValue)
+import Private.Tick exposing (Tick)
 
 
 type alias Scale a b =

--- a/src/Private/Scale/Linear.elm
+++ b/src/Private/Scale/Linear.elm
@@ -1,9 +1,9 @@
-module Private.Scale.Linear exposing (interpolate, createTicks, uninterpolate, inDomain)
+module Private.Scale.Linear exposing (createTicks, inDomain, interpolate, uninterpolate)
 
 import Private.Extras.Float exposing (ln, roundTo)
+import Private.Extras.Interval as Interval exposing (Interval)
 import Private.PointValue exposing (PointValue)
 import Private.Tick as Tick exposing (Tick)
-import Private.Extras.Interval as Interval exposing (Interval)
 
 
 interpolate : Interval -> Interval -> Float -> PointValue Float
@@ -15,7 +15,7 @@ interpolate domain range x =
             else
                 (((x - domain.start) * (range.end - range.start)) / (domain.end - domain.start)) + range.start
     in
-        { value = value, width = 0, originalValue = x }
+    { value = value, width = 0, originalValue = x }
 
 
 uninterpolate : Interval -> Interval -> Float -> Float
@@ -30,9 +30,9 @@ inDomain : Interval -> Float -> Bool
 inDomain domain x =
     let
         extent =
-            Interval.extentOf (domain)
+            Interval.extentOf domain
     in
-        (x >= extent.start) && (x <= extent.end)
+    (x >= extent.start) && (x <= extent.end)
 
 
 
@@ -49,13 +49,13 @@ createTicks numTicks domain range =
             stepSize extent (toFloat numTicks)
 
         min =
-            (toFloat (ceiling (extent.start / step))) * step
+            toFloat (ceiling (extent.start / step)) * step
 
         max =
-            (toFloat (floor (extent.end / step))) * step + step * 0.5
+            toFloat (floor (extent.end / step)) * step + step * 0.5
     in
-        makeTicks min max step
-            |> List.map (createTick (significantDigits step) domain range)
+    makeTicks min max step
+        |> List.map (createTick (significantDigits step) domain range)
 
 
 createTick : Int -> Interval -> Interval -> Float -> Tick
@@ -71,19 +71,19 @@ stepSize extent numTicks =
             Interval.span extent
 
         step =
-            toFloat (10 ^ (floor ((ln (span / numTicks) / ln 10))))
+            toFloat (10 ^ floor (ln (span / numTicks) / ln 10))
 
         err =
             numTicks / span * step
     in
-        if err <= 0.15 then
-            step * 10
-        else if err < 0.35 then
-            step * 5
-        else if err < 0.75 then
-            step * 2
-        else
-            step
+    if err <= 0.15 then
+        step * 10
+    else if err < 0.35 then
+        step * 5
+    else if err < 0.75 then
+        step * 2
+    else
+        step
 
 
 makeTicks : Float -> Float -> Float -> List Float
@@ -96,4 +96,4 @@ makeTicks min max step =
 
 significantDigits : Float -> Int
 significantDigits step =
-    negate (floor ((ln step) / (ln 10) + 0.01))
+    negate (floor (ln step / ln 10 + 0.01))

--- a/src/Private/Scale/Ordinal.elm
+++ b/src/Private/Scale/Ordinal.elm
@@ -26,14 +26,14 @@ uninterpolate : OrdinalMapping -> Float -> String
 uninterpolate mapping x =
     let
         withinHalfStepSize =
-            (\kv -> (abs (.value (Tuple.second kv) - x)) <= mapping.stepSize / 2)
+            \kv -> abs (.value (Tuple.second kv) - x) <= mapping.stepSize / 2
     in
-        case find withinHalfStepSize (Dict.toList mapping.lookup) of
-            Just kv ->
-                Tuple.first kv
+    case find withinHalfStepSize (Dict.toList mapping.lookup) of
+        Just kv ->
+            Tuple.first kv
 
-            Nothing ->
-                ""
+        Nothing ->
+            ""
 
 
 createTicks : OrdinalMapping -> (String -> PointValue String -> Tick) -> List Tick
@@ -53,5 +53,5 @@ buildLookup start step width domain dict =
             pv =
                 { value = start, width = width, originalValue = orgValue }
         in
-            buildLookup (start + step) step width (List.drop 1 domain) <|
-                Dict.insert orgValue pv dict
+        buildLookup (start + step) step width (List.drop 1 domain) <|
+            Dict.insert orgValue pv dict

--- a/src/Private/Scale/OrdinalBands.elm
+++ b/src/Private/Scale/OrdinalBands.elm
@@ -1,10 +1,10 @@
-module Private.Scale.OrdinalBands exposing (interpolate, createTicks, createMapping, uninterpolate, inDomain)
+module Private.Scale.OrdinalBands exposing (createMapping, createTicks, inDomain, interpolate, uninterpolate)
 
-import Private.PointValue exposing (PointValue)
-import Private.Tick as Tick exposing (Tick)
 import Dict exposing (Dict)
 import Private.Extras.Interval exposing (Interval)
+import Private.PointValue exposing (PointValue)
 import Private.Scale.Ordinal as OrdinalScale exposing (OrdinalMapping)
+import Private.Tick as Tick exposing (Tick)
 
 
 interpolate : (List String -> Interval -> OrdinalMapping) -> List String -> Interval -> String -> PointValue String
@@ -42,7 +42,7 @@ createMapping padding outerPadding domain range =
             max range.start range.end
 
         step =
-            (stop - start) / ((toFloat (List.length domain)) - padding + 2 * outerPadding)
+            (stop - start) / (toFloat (List.length domain) - padding + 2 * outerPadding)
 
         bandWidth =
             abs (step * (1 - padding))
@@ -56,6 +56,6 @@ createMapping padding outerPadding domain range =
             else
                 List.reverse domain
     in
-        { lookup = OrdinalScale.buildLookup adjStart step bandWidth adjDomain Dict.empty
-        , stepSize = step
-        }
+    { lookup = OrdinalScale.buildLookup adjStart step bandWidth adjDomain Dict.empty
+    , stepSize = step
+    }

--- a/src/Private/Scale/Utils.elm
+++ b/src/Private/Scale/Utils.elm
@@ -1,10 +1,10 @@
 module Private.Scale.Utils exposing (..)
 
-import Private.Scale exposing (Scale)
-import Private.PointValue exposing (PointValue)
-import Private.Tick exposing (Tick)
 import Private.BoundingBox exposing (BoundingBox)
-import Private.Extras.Interval as Interval exposing (Interval, Interval)
+import Private.Extras.Interval as Interval exposing (Interval)
+import Private.PointValue exposing (PointValue)
+import Private.Scale exposing (Scale)
+import Private.Tick exposing (Tick)
 
 
 type ScaleType
@@ -59,7 +59,7 @@ calculateExtent bBox sType interval =
             else
                 Interval.create (max extent.start bBox.yStart) (min extent.end bBox.yEnd)
     in
-        if Interval.isDescending interval then
-            Interval.reverse calc
-        else
-            calc
+    if Interval.isDescending interval then
+        Interval.reverse calc
+    else
+        calc

--- a/src/Private/Title.elm
+++ b/src/Private/Title.elm
@@ -1,9 +1,9 @@
 module Private.Title exposing (..)
 
-import Svg exposing (svg, Svg, text_, text)
-import Svg.Attributes exposing (textAnchor)
-import Private.Extras.SvgAttributes exposing (x, y)
 import Private.BoundingBox exposing (BoundingBox)
+import Private.Extras.SvgAttributes exposing (x, y)
+import Svg exposing (Svg, svg, text, text_)
+import Svg.Attributes exposing (textAnchor)
 
 
 type alias Model msg =
@@ -41,5 +41,5 @@ toSvg model bBox =
             else
                 model.attrs
     in
-        text_ titleAttrs
-            [ text model.title ]
+    text_ titleAttrs
+        [ text model.title ]

--- a/tests/Test/Plot/InterpolationTest.elm
+++ b/tests/Test/Plot/InterpolationTest.elm
@@ -1,8 +1,8 @@
 module Test.Plot.InterpolationTest exposing (..)
 
+import Expect
 import Plot.Interpolation exposing (..)
 import Test exposing (..)
-import Expect
 import Test.TestUtils.Point exposing (createPoints)
 
 
@@ -17,14 +17,14 @@ linearTests =
     describe "linear"
         [ test "for zero points" <|
             \_ ->
-                (linear [])
+                linear []
                     |> Expect.equal ""
         , test "for one point" <|
             \_ ->
-                (linear (createPoints [ ( 1, 2 ) ]))
+                linear (createPoints [ ( 1, 2 ) ])
                     |> Expect.equal "1,2Z"
         , test "for more than one point" <|
             \_ ->
-                (linear (createPoints [ ( 1, 2 ), ( 3, 4 ) ]))
+                linear (createPoints [ ( 1, 2 ), ( 3, 4 ) ])
                     |> Expect.equal "1,2L3,4"
         ]

--- a/tests/Test/Private/Axis/TicksTest.elm
+++ b/tests/Test/Private/Axis/TicksTest.elm
@@ -1,11 +1,11 @@
 module Test.Private.Axis.TicksTest exposing (..)
 
-import Private.Axis.Ticks exposing (..)
-import Plot.Scale as Scale
-import Plot.Axis as Axis
-import Test exposing (..)
 import Expect
-import Svg.Attributes exposing (x, y, y2, x2, dy, textAnchor, transform)
+import Plot.Axis as Axis
+import Plot.Scale as Scale
+import Private.Axis.Ticks exposing (..)
+import Svg.Attributes exposing (dy, textAnchor, transform, x, x2, y, y2)
+import Test exposing (..)
 
 
 tests : Test
@@ -23,24 +23,24 @@ createTickInfosTests =
         scale =
             Scale.linear ( 0, 1 ) ( 0, 10 ) 1
     in
-        describe "createTickInfos"
-            [ test "for top orient" <|
-                \_ ->
-                    (createTickInfos scale Axis.Top)
-                        |> Expect.equal [ { label = "0", translation = ( 0, 0 ) }, { label = "1", translation = ( 10, 0 ) } ]
-            , test "for bottom orient" <|
-                \_ ->
-                    (createTickInfos scale Axis.Bottom)
-                        |> Expect.equal [ { label = "0", translation = ( 0, 0 ) }, { label = "1", translation = ( 10, 0 ) } ]
-            , test "for left orient" <|
-                \_ ->
-                    (createTickInfos scale Axis.Left)
-                        |> Expect.equal [ { label = "0", translation = ( 0, 0 ) }, { label = "1", translation = ( 0, 10 ) } ]
-            , test "for right orient" <|
-                \_ ->
-                    (createTickInfos scale Axis.Right)
-                        |> Expect.equal [ { label = "0", translation = ( 0, 0 ) }, { label = "1", translation = ( 0, 10 ) } ]
-            ]
+    describe "createTickInfos"
+        [ test "for top orient" <|
+            \_ ->
+                createTickInfos scale Axis.Top
+                    |> Expect.equal [ { label = "0", translation = ( 0, 0 ) }, { label = "1", translation = ( 10, 0 ) } ]
+        , test "for bottom orient" <|
+            \_ ->
+                createTickInfos scale Axis.Bottom
+                    |> Expect.equal [ { label = "0", translation = ( 0, 0 ) }, { label = "1", translation = ( 10, 0 ) } ]
+        , test "for left orient" <|
+            \_ ->
+                createTickInfos scale Axis.Left
+                    |> Expect.equal [ { label = "0", translation = ( 0, 0 ) }, { label = "1", translation = ( 0, 10 ) } ]
+        , test "for right orient" <|
+            \_ ->
+                createTickInfos scale Axis.Right
+                    |> Expect.equal [ { label = "0", translation = ( 0, 0 ) }, { label = "1", translation = ( 0, 10 ) } ]
+        ]
 
 
 innerTickLineAttributesTests : Test
@@ -48,19 +48,19 @@ innerTickLineAttributesTests =
     describe "innerTickLineAttributes"
         [ test "for top orient" <|
             \_ ->
-                (innerTickLineAttributes Axis.Top 6)
+                innerTickLineAttributes Axis.Top 6
                     |> Expect.equal [ x2 "0", y2 "-6" ]
         , test "for bottom orient" <|
             \_ ->
-                (innerTickLineAttributes Axis.Bottom 6)
+                innerTickLineAttributes Axis.Bottom 6
                     |> Expect.equal [ x2 "0", y2 "6" ]
         , test "for left orient" <|
             \_ ->
-                (innerTickLineAttributes Axis.Left 4)
+                innerTickLineAttributes Axis.Left 4
                     |> Expect.equal [ x2 "-4", y2 "0" ]
         , test "for right orient" <|
             \_ ->
-                (innerTickLineAttributes Axis.Right 4)
+                innerTickLineAttributes Axis.Right 4
                     |> Expect.equal [ x2 "4", y2 "0" ]
         ]
 
@@ -70,26 +70,26 @@ labelAttributesTests =
     describe "labelAttributes"
         [ test "for top orient" <|
             \_ ->
-                (labelAttributes Axis.Top 6 0 0)
+                labelAttributes Axis.Top 6 0 0
                     |> Expect.equal [ x "0", y "-6", dy "0em", textAnchor "middle" ]
         , test "for bottom orient" <|
             \_ ->
-                (labelAttributes Axis.Bottom 6 0 0)
+                labelAttributes Axis.Bottom 6 0 0
                     |> Expect.equal [ x "0", y "6", dy ".71em", textAnchor "middle" ]
         , test "for left orient" <|
             \_ ->
-                (labelAttributes Axis.Left 6 0 0)
+                labelAttributes Axis.Left 6 0 0
                     |> Expect.equal [ x "-6", y "0", dy ".32em", textAnchor "end" ]
         , test "for right orient" <|
             \_ ->
-                (labelAttributes Axis.Right 6 0 0)
+                labelAttributes Axis.Right 6 0 0
                     |> Expect.equal [ x "6", y "0", dy ".32em", textAnchor "start" ]
         , test "tick padding is included in the ofset" <|
             \_ ->
-                (labelAttributes Axis.Right 8 2 0)
+                labelAttributes Axis.Right 8 2 0
                     |> Expect.equal [ x "10", y "0", dy ".32em", textAnchor "start" ]
         , test "when rotation is not zero a rotaion transform is included" <|
             \_ ->
-                (labelAttributes Axis.Right 6 0 25)
+                labelAttributes Axis.Right 6 0 25
                     |> Expect.equal [ x "6", y "0", dy ".32em", textAnchor "start", transform "rotate(25,6,0)" ]
         ]

--- a/tests/Test/Private/Axis/TitleTest.elm
+++ b/tests/Test/Private/Axis/TitleTest.elm
@@ -1,11 +1,11 @@
 module Test.Private.Axis.TitleTest exposing (..)
 
-import Private.Axis.Title exposing (..)
-import Plot.Axis as Axis
-import Private.Extras.Interval as Interval
-import Svg.Attributes exposing (x, y, textAnchor, stroke, transform)
-import Test exposing (..)
 import Expect
+import Plot.Axis as Axis
+import Private.Axis.Title exposing (..)
+import Private.Extras.Interval as Interval
+import Svg.Attributes exposing (stroke, textAnchor, transform, x, y)
+import Test exposing (..)
 
 
 tests : Test
@@ -22,16 +22,16 @@ createTitleTests =
         createTitle_ =
             createTitle (Interval.createFromTuple ( 0, 100 )) Axis.Top 0 0 [] Nothing
     in
-        describe "createTitle"
-            [ test "when a title string is given an svg is created for it" <|
-                \_ ->
-                    (List.length (createTitle_ (Just "title")))
-                        |> Expect.equal 1
-            , test "when no title string is given then nothing is created " <|
-                \_ ->
-                    (List.length (createTitle_ Nothing))
-                        |> Expect.equal 0
-            ]
+    describe "createTitle"
+        [ test "when a title string is given an svg is created for it" <|
+            \_ ->
+                List.length (createTitle_ (Just "title"))
+                    |> Expect.equal 1
+        , test "when no title string is given then nothing is created " <|
+            \_ ->
+                List.length (createTitle_ Nothing)
+                    |> Expect.equal 0
+        ]
 
 
 titleAttrsTests : Test
@@ -40,33 +40,33 @@ titleAttrsTests =
         titleAttrs_ =
             titleAttrs (Interval.createFromTuple ( 0, 100 ))
     in
-        describe "titleAttrs"
-            [ test "for a top orient it places it above the axis" <|
-                \_ ->
-                    (titleAttrs_ Axis.Top 1 1 [] Nothing)
-                        |> Expect.equal [ textAnchor "middle", x "50", y "-32" ]
-            , test "for a bottom orient it places it bellow the axis" <|
-                \_ ->
-                    (titleAttrs_ Axis.Bottom 1 1 [] Nothing)
-                        |> Expect.equal [ textAnchor "middle", x "50", y "32" ]
-            , test "for a left orient it places it to the left of the axis" <|
-                \_ ->
-                    (titleAttrs_ Axis.Left 1 1 [] Nothing)
-                        |> Expect.equal [ textAnchor "middle", x "-32", y "50", transform "rotate(-90,-32,50)" ]
-            , test "for a right orient it places it to the right of the axis" <|
-                \_ ->
-                    (titleAttrs_ Axis.Right 1 1 [] Nothing)
-                        |> Expect.equal [ textAnchor "middle", x "32", y "50", transform "rotate(90,32,50)" ]
-            , test "when an offset is given then it is used instead" <|
-                \_ ->
-                    (titleAttrs_ Axis.Top 1 1 [] (Just 21))
-                        |> Expect.equal [ textAnchor "middle", x "50", y "-21" ]
-            , test "it is placed in the middle of the axis" <|
-                \_ ->
-                    (titleAttrs (Interval.createFromTuple ( 100, 200 )) Axis.Top 1 1 [] (Just 21))
-                        |> Expect.equal [ textAnchor "middle", x "150", y "-21" ]
-            , test "additional attrs are appended to the end" <|
-                \_ ->
-                    (titleAttrs_ Axis.Top 1 1 [ stroke "red" ] Nothing)
-                        |> Expect.equal [ textAnchor "middle", x "50", y "-32", stroke "red" ]
-            ]
+    describe "titleAttrs"
+        [ test "for a top orient it places it above the axis" <|
+            \_ ->
+                titleAttrs_ Axis.Top 1 1 [] Nothing
+                    |> Expect.equal [ textAnchor "middle", x "50", y "-32" ]
+        , test "for a bottom orient it places it bellow the axis" <|
+            \_ ->
+                titleAttrs_ Axis.Bottom 1 1 [] Nothing
+                    |> Expect.equal [ textAnchor "middle", x "50", y "32" ]
+        , test "for a left orient it places it to the left of the axis" <|
+            \_ ->
+                titleAttrs_ Axis.Left 1 1 [] Nothing
+                    |> Expect.equal [ textAnchor "middle", x "-32", y "50", transform "rotate(-90,-32,50)" ]
+        , test "for a right orient it places it to the right of the axis" <|
+            \_ ->
+                titleAttrs_ Axis.Right 1 1 [] Nothing
+                    |> Expect.equal [ textAnchor "middle", x "32", y "50", transform "rotate(90,32,50)" ]
+        , test "when an offset is given then it is used instead" <|
+            \_ ->
+                titleAttrs_ Axis.Top 1 1 [] (Just 21)
+                    |> Expect.equal [ textAnchor "middle", x "50", y "-21" ]
+        , test "it is placed in the middle of the axis" <|
+            \_ ->
+                titleAttrs (Interval.createFromTuple ( 100, 200 )) Axis.Top 1 1 [] (Just 21)
+                    |> Expect.equal [ textAnchor "middle", x "150", y "-21" ]
+        , test "additional attrs are appended to the end" <|
+            \_ ->
+                titleAttrs_ Axis.Top 1 1 [ stroke "red" ] Nothing
+                    |> Expect.equal [ textAnchor "middle", x "50", y "-32", stroke "red" ]
+        ]

--- a/tests/Test/Private/Axis/ViewTest.elm
+++ b/tests/Test/Private/Axis/ViewTest.elm
@@ -1,14 +1,14 @@
 module Test.Private.Axis.ViewTest exposing (..)
 
-import Private.Axis.View exposing (..)
-import Plot.Scale as Scale exposing (LinearScale)
-import Plot.Axis as Axis
-import Private.BoundingBox as BoundingBox exposing (BoundingBox)
-import Test exposing (..)
 import Expect
-import Svg.Attributes exposing (transform)
-import Test.TestUtils.Intervals exposing (assertInterval)
+import Plot.Axis as Axis
+import Plot.Scale as Scale exposing (LinearScale)
+import Private.Axis.View exposing (..)
+import Private.BoundingBox as BoundingBox exposing (BoundingBox)
 import Private.Extras.Interval as Interval
+import Svg.Attributes exposing (transform)
+import Test exposing (..)
+import Test.TestUtils.Intervals exposing (assertInterval)
 
 
 tests : Test
@@ -41,72 +41,72 @@ calculateAxisExtentTests =
         calculateExtent_ =
             calculateAxisExtent boundingBox
     in
-        describe "calculateAxisExtent"
-            [ test "for the x axis and a range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ Axis.Top range
-            , test "for bottom orient and a range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ Axis.Bottom range
-            , test "for left orient and a range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ Axis.Left range
-            , test "for right orient and a range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ Axis.Right range
-            , test "for the x axis and a descending range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ Axis.Top descendingRange
-            , test "for bottom orient and a descending range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ Axis.Bottom descendingRange
-            , test "for left orient and a descending range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ Axis.Left descendingRange
-            , test "for right orient and a descending range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ Axis.Right descendingRange
-            , test "for the x axis and a range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 5, 95 ) <|
-                        calculateExtent_ Axis.Top largeRange
-            , test "for bottom orient and a range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 5, 95 ) <|
-                        calculateExtent_ Axis.Bottom largeRange
-            , test "for left orient and a range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 2, 97 ) <|
-                        calculateExtent_ Axis.Left largeRange
-            , test "for right orient and a range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 2, 97 ) <|
-                        calculateExtent_ Axis.Right largeRange
-            , test "for the x axis and a descending range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 5, 95 ) <|
-                        calculateExtent_ Axis.Top largeDescending
-            , test "for bottom orient and a descending range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 5, 95 ) <|
-                        calculateExtent_ Axis.Bottom largeDescending
-            , test "for left orient and a descending range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 2, 97 ) <|
-                        calculateExtent_ Axis.Left largeDescending
-            , test "for right orient and a descending range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 2, 97 ) <|
-                        calculateExtent_ Axis.Right largeDescending
-            ]
+    describe "calculateAxisExtent"
+        [ test "for the x axis and a range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ Axis.Top range
+        , test "for bottom orient and a range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ Axis.Bottom range
+        , test "for left orient and a range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ Axis.Left range
+        , test "for right orient and a range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ Axis.Right range
+        , test "for the x axis and a descending range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ Axis.Top descendingRange
+        , test "for bottom orient and a descending range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ Axis.Bottom descendingRange
+        , test "for left orient and a descending range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ Axis.Left descendingRange
+        , test "for right orient and a descending range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ Axis.Right descendingRange
+        , test "for the x axis and a range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 5, 95 ) <|
+                    calculateExtent_ Axis.Top largeRange
+        , test "for bottom orient and a range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 5, 95 ) <|
+                    calculateExtent_ Axis.Bottom largeRange
+        , test "for left orient and a range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 2, 97 ) <|
+                    calculateExtent_ Axis.Left largeRange
+        , test "for right orient and a range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 2, 97 ) <|
+                    calculateExtent_ Axis.Right largeRange
+        , test "for the x axis and a descending range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 5, 95 ) <|
+                    calculateExtent_ Axis.Top largeDescending
+        , test "for bottom orient and a descending range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 5, 95 ) <|
+                    calculateExtent_ Axis.Bottom largeDescending
+        , test "for left orient and a descending range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 2, 97 ) <|
+                    calculateExtent_ Axis.Left largeDescending
+        , test "for right orient and a descending range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 2, 97 ) <|
+                    calculateExtent_ Axis.Right largeDescending
+        ]
 
 
 axisTranslationTests : Test
@@ -115,19 +115,19 @@ axisTranslationTests =
         [ test "for top orient" <|
             \_ ->
                 axisTranslation boundingBox Axis.Top
-                    |> Expect.equal ((transform "translate(0,2)"))
+                    |> Expect.equal (transform "translate(0,2)")
         , test "for bottom orient" <|
             \_ ->
                 axisTranslation boundingBox Axis.Bottom
-                    |> Expect.equal ((transform "translate(0,100)"))
+                    |> Expect.equal (transform "translate(0,100)")
         , test "for left orient" <|
             \_ ->
                 axisTranslation boundingBox Axis.Left
-                    |> Expect.equal ((transform "translate(5,0)"))
+                    |> Expect.equal (transform "translate(5,0)")
         , test "for right orient" <|
             \_ ->
                 axisTranslation boundingBox Axis.Right
-                    |> Expect.equal ((transform "translate(95,0)"))
+                    |> Expect.equal (transform "translate(95,0)")
         ]
 
 
@@ -137,39 +137,39 @@ pathStringTests =
         [ test "for top orient" <|
             \_ ->
                 pathString boundingBox scale Axis.Top 6
-                    |> Expect.equal ("M10,-6V0H90V-6")
+                    |> Expect.equal "M10,-6V0H90V-6"
         , test "for bottom orient" <|
             \_ ->
                 pathString boundingBox scale Axis.Bottom 6
-                    |> Expect.equal ("M10,6V0H90V6")
+                    |> Expect.equal "M10,6V0H90V6"
         , test "for left orient" <|
             \_ ->
                 pathString boundingBox scale Axis.Left 6
-                    |> Expect.equal ("M-6,10H0V90H-6")
+                    |> Expect.equal "M-6,10H0V90H-6"
         , test "for right orient" <|
             \_ ->
                 pathString boundingBox scale Axis.Right 6
-                    |> Expect.equal ("M6,10H0V90H6")
+                    |> Expect.equal "M6,10H0V90H6"
         , test "for a scale that does not fit inside the x boundings" <|
             \_ ->
                 pathString boundingBox (Scale.linear ( 0, 105 ) ( 0, 105 ) 1) Axis.Top 6
-                    |> Expect.equal ("M5,-6V0H95V-6")
+                    |> Expect.equal "M5,-6V0H95V-6"
         , test "for a scale that does not fit inside the y boundings" <|
             \_ ->
                 pathString boundingBox (Scale.linear ( 0, 105 ) ( 0, 105 ) 1) Axis.Left 6
-                    |> Expect.equal ("M-6,2H0V100H-6")
+                    |> Expect.equal "M-6,2H0V100H-6"
         , test "for x axis with a descending scale that does not fit inside the x boundings" <|
             \_ ->
                 pathString boundingBox (Scale.linear ( 0, 105 ) ( 105, 0 ) 1) Axis.Top 6
-                    |> Expect.equal ("M5,-6V0H95V-6")
+                    |> Expect.equal "M5,-6V0H95V-6"
         , test "for y axis with a descending scale that does not fit inside the y boundings" <|
             \_ ->
                 pathString boundingBox (Scale.linear ( 0, 105 ) ( 105, 0 ) 1) Axis.Left 6
-                    |> Expect.equal ("M-6,2H0V100H-6")
+                    |> Expect.equal "M-6,2H0V100H-6"
         , test "for a non-default tick size" <|
             \_ ->
                 pathString boundingBox scale Axis.Top 8
-                    |> Expect.equal ("M10,-8V0H90V-8")
+                    |> Expect.equal "M10,-8V0H90V-8"
         ]
 
 

--- a/tests/Test/Private/BarsTest.elm
+++ b/tests/Test/Private/BarsTest.elm
@@ -1,10 +1,10 @@
 module Test.Private.BarsTest exposing (..)
 
-import Private.Bars exposing (..)
-import Test exposing (..)
 import Expect
-import Svg.Attributes exposing (x, y, width, height, stroke)
+import Private.Bars exposing (..)
 import Private.BoundingBox as BoundingBox
+import Svg.Attributes exposing (height, stroke, width, x, y)
+import Test exposing (..)
 
 
 tests : Test
@@ -25,17 +25,17 @@ barAttrsTests =
         boundingBox =
             BoundingBox.create 10 90 20 100
     in
-        describe "barAttrs"
-            [ test "for a top orient" <|
-                \_ ->
-                    barAttrs boundingBox Vertical (point [])
-                        |> Expect.equal ([ x "50", y "40", width "20", height "60" ])
-            , test "for a vertical orient" <|
-                \_ ->
-                    barAttrs boundingBox Horizontal (point [])
-                        |> Expect.equal ([ x "10", y "40", width "40", height "10" ])
-            , test "additional svg attributes can be added to the position attributes" <|
-                \_ ->
-                    barAttrs boundingBox Horizontal (point [ stroke "red" ])
-                        |> Expect.equal ([ x "10", y "40", width "40", height "10", stroke "red" ])
-            ]
+    describe "barAttrs"
+        [ test "for a top orient" <|
+            \_ ->
+                barAttrs boundingBox Vertical (point [])
+                    |> Expect.equal [ x "50", y "40", width "20", height "60" ]
+        , test "for a vertical orient" <|
+            \_ ->
+                barAttrs boundingBox Horizontal (point [])
+                    |> Expect.equal [ x "10", y "40", width "40", height "10" ]
+        , test "additional svg attributes can be added to the position attributes" <|
+            \_ ->
+                barAttrs boundingBox Horizontal (point [ stroke "red" ])
+                    |> Expect.equal [ x "10", y "40", width "40", height "10", stroke "red" ]
+        ]

--- a/tests/Test/Private/BoundingBoxTest.elm
+++ b/tests/Test/Private/BoundingBoxTest.elm
@@ -1,9 +1,9 @@
 module Test.Private.BoundingBoxTest exposing (..)
 
+import Expect
 import Private.BoundingBox as BoundingBox
 import Private.Dimensions as Dimensions
 import Test exposing (..)
-import Expect
 
 
 tests : Test
@@ -18,17 +18,17 @@ fromTests =
         dims =
             Dimensions.create 100 50
     in
-        describe "from"
-            [ test "with margins that are not too large" <|
-                \_ ->
-                    BoundingBox.from dims { left = 30, right = 40, top = 10, bottom = 20 }
-                        |> Expect.equal ((BoundingBox.create 30 60 10 30))
-            , test "horizontal margins that are too large" <|
-                \_ ->
-                    BoundingBox.from dims { left = 60, right = 45, top = 10, bottom = 20 }
-                        |> Expect.equal ((BoundingBox.create 0 0 0 0))
-            , test "vertical margins that are too large" <|
-                \_ ->
-                    BoundingBox.from dims { left = 30, right = 40, top = 30, bottom = 40 }
-                        |> Expect.equal ((BoundingBox.create 0 0 0 0))
-            ]
+    describe "from"
+        [ test "with margins that are not too large" <|
+            \_ ->
+                BoundingBox.from dims { left = 30, right = 40, top = 10, bottom = 20 }
+                    |> Expect.equal (BoundingBox.create 30 60 10 30)
+        , test "horizontal margins that are too large" <|
+            \_ ->
+                BoundingBox.from dims { left = 60, right = 45, top = 10, bottom = 20 }
+                    |> Expect.equal (BoundingBox.create 0 0 0 0)
+        , test "vertical margins that are too large" <|
+            \_ ->
+                BoundingBox.from dims { left = 30, right = 40, top = 30, bottom = 40 }
+                    |> Expect.equal (BoundingBox.create 0 0 0 0)
+        ]

--- a/tests/Test/Private/Extras/FloatTest.elm
+++ b/tests/Test/Private/Extras/FloatTest.elm
@@ -1,8 +1,8 @@
 module Test.Private.Extras.FloatTest exposing (..)
 
+import Expect
 import Private.Extras.Float exposing (..)
 import Test exposing (..)
-import Expect
 
 
 tests : Test
@@ -34,22 +34,22 @@ roundTests =
     describe "roundTo"
         [ test "rounding float with no decimal places" <|
             \_ ->
-                (roundTo 3 0)
+                roundTo 3 0
                     |> Expect.equal 3
         , test "rounding float with more decimal places than it has" <|
             \_ ->
-                (roundTo 3.1 2)
+                roundTo 3.1 2
                     |> Expect.equal 3.1
         , test "rounding float down" <|
             \_ ->
-                (roundTo 3.14159 2)
+                roundTo 3.14159 2
                     |> Expect.equal 3.14
         , test "rounding float up" <|
             \_ ->
-                (roundTo 3.14159 3)
+                roundTo 3.14159 3
                     |> Expect.equal 3.142
         , test "when given a negative number returns the number" <|
             \_ ->
-                (roundTo 3 -1)
+                roundTo 3 -1
                     |> Expect.equal 3
         ]

--- a/tests/Test/Private/Extras/IntervalTest.elm
+++ b/tests/Test/Private/Extras/IntervalTest.elm
@@ -1,8 +1,8 @@
 module Test.Private.Extras.IntervalTest exposing (..)
 
+import Expect
 import Private.Extras.Interval as Interval exposing (..)
 import Test exposing (..)
-import Expect
 import Test.TestUtils.Intervals exposing (assertInterval)
 
 

--- a/tests/Test/Private/PointsTest.elm
+++ b/tests/Test/Private/PointsTest.elm
@@ -1,9 +1,9 @@
 module Test.Private.PointsTest exposing (..)
 
-import Private.Points exposing (..)
-import Test exposing (..)
 import Expect
 import Plot.Scale as Scale
+import Private.Points exposing (..)
+import Test exposing (..)
 import Test.TestUtils.Point exposing (createPoints)
 
 
@@ -25,17 +25,17 @@ interpolateTests =
         interpolate_ =
             \points -> List.length (interpolate xScale yScale points)
     in
-        describe "interpolate"
-            [ test "points within the domain of the x and y scale are not filtered out" <|
-                \_ ->
-                    interpolate_ (createPoints [ ( 1, 1 ), ( 0.5, 0.5 ) ])
-                        |> Expect.equal (2)
-            , test "points ouside of the x domain are filtered out" <|
-                \_ ->
-                    interpolate_ (createPoints [ ( 1.5, 1 ), ( -1, -1 ) ])
-                        |> Expect.equal (0)
-            , test "points ouside of the y domain are filtered out" <|
-                \_ ->
-                    interpolate_ (createPoints [ ( 1, 1.5 ), ( 1, -2 ) ])
-                        |> Expect.equal (0)
-            ]
+    describe "interpolate"
+        [ test "points within the domain of the x and y scale are not filtered out" <|
+            \_ ->
+                interpolate_ (createPoints [ ( 1, 1 ), ( 0.5, 0.5 ) ])
+                    |> Expect.equal 2
+        , test "points ouside of the x domain are filtered out" <|
+            \_ ->
+                interpolate_ (createPoints [ ( 1.5, 1 ), ( -1, -1 ) ])
+                    |> Expect.equal 0
+        , test "points ouside of the y domain are filtered out" <|
+            \_ ->
+                interpolate_ (createPoints [ ( 1, 1.5 ), ( 1, -2 ) ])
+                    |> Expect.equal 0
+        ]

--- a/tests/Test/Private/Scale/LinearTest.elm
+++ b/tests/Test/Private/Scale/LinearTest.elm
@@ -1,9 +1,9 @@
 module Test.Private.Scale.LinearTest exposing (..)
 
-import Private.Scale.Linear exposing (..)
-import Test exposing (..)
 import Expect
 import Private.Extras.Interval as Interval
+import Private.Scale.Linear exposing (..)
+import Test exposing (..)
 
 
 tests : Test
@@ -26,24 +26,24 @@ interpolateTests =
             \d r v ->
                 interpolate (Interval.createFromTuple d) (Interval.createFromTuple r) v
     in
-        describe "interpolate"
-            [ test "for a regular domain" <|
-                \_ ->
-                    (interpolate_ ( 0, 1 ) range 0.25).value
-                        |> Expect.equal (4)
-            , test "for a reverse domain" <|
-                \_ ->
-                    (interpolate_ ( -1, 0 ) range -0.25).value
-                        |> Expect.equal (12)
-            , test "when the min and max of the domain is equal" <|
-                \_ ->
-                    (interpolate_ ( 1, 1 ) range 2).value
-                        |> Expect.equal (0)
-            , test "the band width is always 0" <|
-                \_ ->
-                    (interpolate_ ( 0, 1 ) range 0.25).width
-                        |> Expect.equal (0)
-            ]
+    describe "interpolate"
+        [ test "for a regular domain" <|
+            \_ ->
+                (interpolate_ ( 0, 1 ) range 0.25).value
+                    |> Expect.equal 4
+        , test "for a reverse domain" <|
+            \_ ->
+                (interpolate_ ( -1, 0 ) range -0.25).value
+                    |> Expect.equal 12
+        , test "when the min and max of the domain is equal" <|
+            \_ ->
+                (interpolate_ ( 1, 1 ) range 2).value
+                    |> Expect.equal 0
+        , test "the band width is always 0" <|
+            \_ ->
+                (interpolate_ ( 0, 1 ) range 0.25).width
+                    |> Expect.equal 0
+        ]
 
 
 uninterpolateTests : Test
@@ -56,20 +56,20 @@ uninterpolateTests =
             \d r v ->
                 uninterpolate (Interval.createFromTuple d) (Interval.createFromTuple r) v
     in
-        describe "uninterpolate"
-            [ test "for a regular domain" <|
-                \_ ->
-                    uninteropolate_ domain ( 0, 16 ) 4
-                        |> Expect.equal (0.25)
-            , test "for a reverse domain" <|
-                \_ ->
-                    uninteropolate_ domain ( 16, 0 ) 12
-                        |> Expect.equal (0.25)
-            , test "when the min and max of the range is equal" <|
-                \_ ->
-                    uninteropolate_ domain ( 16, 16 ) 2
-                        |> Expect.equal (0)
-            ]
+    describe "uninterpolate"
+        [ test "for a regular domain" <|
+            \_ ->
+                uninteropolate_ domain ( 0, 16 ) 4
+                    |> Expect.equal 0.25
+        , test "for a reverse domain" <|
+            \_ ->
+                uninteropolate_ domain ( 16, 0 ) 12
+                    |> Expect.equal 0.25
+        , test "when the min and max of the range is equal" <|
+            \_ ->
+                uninteropolate_ domain ( 16, 16 ) 2
+                    |> Expect.equal 0
+        ]
 
 
 createTicksTests : Test
@@ -82,44 +82,44 @@ createTicksTests =
             \num d r ->
                 createTicks num (Interval.createFromTuple d) (Interval.createFromTuple r)
     in
-        describe "createTicks"
-            [ test "for a regular domain and 1 tick" <|
-                \_ ->
-                    List.map .position (createTicks_ 1 ( 0, 1 ) range)
-                        |> Expect.equal ([ 0, 10 ])
-            , test "for a regular domain and 2 ticks" <|
-                \_ ->
-                    List.map .position (createTicks_ 2 ( 0, 1 ) range)
-                        |> Expect.equal ([ 0, 5, 10 ])
-            , test "for a regular domain and 5 ticks" <|
-                \_ ->
-                    List.map .position (createTicks_ 5 ( 0, 1 ) range)
-                        |> Expect.equal ([ 0, 2, 4, 6, 8, 10 ])
-            , test "for a regular domain and 10 ticks" <|
-                \_ ->
-                    List.map .position (createTicks_ 10 ( 0, 1 ) range)
-                        |> Expect.equal (List.map toFloat <| List.range 0 10)
-            , test "for a reverse domain and 1 tick" <|
-                \_ ->
-                    List.map .position (createTicks_ 1 ( 1, 0 ) range)
-                        |> Expect.equal ([ 10, 0 ])
-            , test "for a reverse domain and 2 ticks" <|
-                \_ ->
-                    List.map .position (createTicks_ 2 ( 1, 0 ) range)
-                        |> Expect.equal ([ 10, 5, 0 ])
-            , test "for a reverse domain and 5 ticks" <|
-                \_ ->
-                    List.map .position (createTicks_ 5 ( 1, 0 ) range)
-                        |> Expect.equal ([ 10, 8, 6, 4, 2, 0 ])
-            , test "for a reverse domain and 10 ticks" <|
-                \_ ->
-                    List.map .position (createTicks_ 10 ( 1, 0 ) range)
-                        |> Expect.equal (List.map toFloat <| List.reverse <| List.range 0 10)
-            , test "for a larger domain when no rounding should take place" <|
-                \_ ->
-                    List.map .position (createTicks_ 10 ( 0, 400 ) ( 70, 330 ))
-                        |> Expect.equal ([ 70, 102.5, 135, 167.5, 200, 232.5, 265, 297.5, 330 ])
-            ]
+    describe "createTicks"
+        [ test "for a regular domain and 1 tick" <|
+            \_ ->
+                List.map .position (createTicks_ 1 ( 0, 1 ) range)
+                    |> Expect.equal [ 0, 10 ]
+        , test "for a regular domain and 2 ticks" <|
+            \_ ->
+                List.map .position (createTicks_ 2 ( 0, 1 ) range)
+                    |> Expect.equal [ 0, 5, 10 ]
+        , test "for a regular domain and 5 ticks" <|
+            \_ ->
+                List.map .position (createTicks_ 5 ( 0, 1 ) range)
+                    |> Expect.equal [ 0, 2, 4, 6, 8, 10 ]
+        , test "for a regular domain and 10 ticks" <|
+            \_ ->
+                List.map .position (createTicks_ 10 ( 0, 1 ) range)
+                    |> Expect.equal (List.map toFloat <| List.range 0 10)
+        , test "for a reverse domain and 1 tick" <|
+            \_ ->
+                List.map .position (createTicks_ 1 ( 1, 0 ) range)
+                    |> Expect.equal [ 10, 0 ]
+        , test "for a reverse domain and 2 ticks" <|
+            \_ ->
+                List.map .position (createTicks_ 2 ( 1, 0 ) range)
+                    |> Expect.equal [ 10, 5, 0 ]
+        , test "for a reverse domain and 5 ticks" <|
+            \_ ->
+                List.map .position (createTicks_ 5 ( 1, 0 ) range)
+                    |> Expect.equal [ 10, 8, 6, 4, 2, 0 ]
+        , test "for a reverse domain and 10 ticks" <|
+            \_ ->
+                List.map .position (createTicks_ 10 ( 1, 0 ) range)
+                    |> Expect.equal (List.map toFloat <| List.reverse <| List.range 0 10)
+        , test "for a larger domain when no rounding should take place" <|
+            \_ ->
+                List.map .position (createTicks_ 10 ( 0, 400 ) ( 70, 330 ))
+                    |> Expect.equal [ 70, 102.5, 135, 167.5, 200, 232.5, 265, 297.5, 330 ]
+        ]
 
 
 inDomainTests : Test
@@ -129,33 +129,33 @@ inDomainTests =
             \d v ->
                 inDomain (Interval.createFromTuple d) v
     in
-        describe "inDomain"
-            [ test "in the domain for an ascending domain" <|
-                \_ ->
-                    inDomain_ ( 0, 1 ) 0.5
-                        |> Expect.equal (True)
-            , test "less than the min of domain for an ascending domain" <|
-                \_ ->
-                    inDomain_ ( 0, 1 ) -1
-                        |> Expect.equal (False)
-            , test "greater than the max of domain for an ascending domain" <|
-                \_ ->
-                    inDomain_ ( 0, 1 ) 2
-                        |> Expect.equal (False)
-            , test "in the domain for an descending domain" <|
-                \_ ->
-                    inDomain_ ( 1, 0 ) 0.5
-                        |> Expect.equal (True)
-            , test "less than the min of domain for an descending domain" <|
-                \_ ->
-                    inDomain_ ( 1, 0 ) -1
-                        |> Expect.equal (False)
-            , test "greater than the max of domain for an descending domain" <|
-                \_ ->
-                    inDomain_ ( 1, 0 ) 2
-                        |> Expect.equal (False)
-            , test "equal to the min or max of the domain" <|
-                \_ ->
-                    List.map (inDomain_ ( 1, 0 )) [ 0, 1 ]
-                        |> Expect.equal ([ True, True ])
-            ]
+    describe "inDomain"
+        [ test "in the domain for an ascending domain" <|
+            \_ ->
+                inDomain_ ( 0, 1 ) 0.5
+                    |> Expect.equal True
+        , test "less than the min of domain for an ascending domain" <|
+            \_ ->
+                inDomain_ ( 0, 1 ) -1
+                    |> Expect.equal False
+        , test "greater than the max of domain for an ascending domain" <|
+            \_ ->
+                inDomain_ ( 0, 1 ) 2
+                    |> Expect.equal False
+        , test "in the domain for an descending domain" <|
+            \_ ->
+                inDomain_ ( 1, 0 ) 0.5
+                    |> Expect.equal True
+        , test "less than the min of domain for an descending domain" <|
+            \_ ->
+                inDomain_ ( 1, 0 ) -1
+                    |> Expect.equal False
+        , test "greater than the max of domain for an descending domain" <|
+            \_ ->
+                inDomain_ ( 1, 0 ) 2
+                    |> Expect.equal False
+        , test "equal to the min or max of the domain" <|
+            \_ ->
+                List.map (inDomain_ ( 1, 0 )) [ 0, 1 ]
+                    |> Expect.equal [ True, True ]
+        ]

--- a/tests/Test/Private/Scale/OrdinalBandsTest.elm
+++ b/tests/Test/Private/Scale/OrdinalBandsTest.elm
@@ -1,11 +1,11 @@
 module Test.Private.Scale.OrdinalBandsTest exposing (..)
 
 import Dict exposing (Dict)
-import Test exposing (..)
 import Expect
-import Private.Scale.OrdinalBands exposing (..)
 import Private.Extras.Interval as Interval
-import Test.TestUtils.Ordinal exposing (expectedInterpolation, expectedTicks, expectedMapping)
+import Private.Scale.OrdinalBands exposing (..)
+import Test exposing (..)
+import Test.TestUtils.Ordinal exposing (expectedInterpolation, expectedMapping, expectedTicks)
 
 
 tests : Test
@@ -31,24 +31,24 @@ createMappingTests =
         expected =
             expectedMapping domain
     in
-        describe "createMapping"
-            [ test "without any paddings" <|
-                \_ ->
-                    Dict.toList (createMapping 0 0 domain range).lookup
-                        |> Expect.equal ((expected 40 [ 0, 40, 80 ]))
-            , test "with a padding set" <|
-                \_ ->
-                    Dict.toList (createMapping 0.2 0.2 domain range).lookup
-                        |> Expect.equal ((expected 30 [ 7.5, 45, 82.5 ]))
-            , test "with a padding and a different outer padding set" <|
-                \_ ->
-                    Dict.toList (createMapping 0.2 0.1 domain range).lookup
-                        |> Expect.equal ((expected 32 [ 4, 44, 84 ]))
-            , test "with a descending range" <|
-                \_ ->
-                    Dict.toList (createMapping 0.2 0.2 domain (Interval.createFromTuple ( 120, 0 ))).lookup
-                        |> Expect.equal ((expected 30 [ 82.5, 45, 7.5 ]))
-            ]
+    describe "createMapping"
+        [ test "without any paddings" <|
+            \_ ->
+                Dict.toList (createMapping 0 0 domain range).lookup
+                    |> Expect.equal (expected 40 [ 0, 40, 80 ])
+        , test "with a padding set" <|
+            \_ ->
+                Dict.toList (createMapping 0.2 0.2 domain range).lookup
+                    |> Expect.equal (expected 30 [ 7.5, 45, 82.5 ])
+        , test "with a padding and a different outer padding set" <|
+            \_ ->
+                Dict.toList (createMapping 0.2 0.1 domain range).lookup
+                    |> Expect.equal (expected 32 [ 4, 44, 84 ])
+        , test "with a descending range" <|
+            \_ ->
+                Dict.toList (createMapping 0.2 0.2 domain (Interval.createFromTuple ( 120, 0 ))).lookup
+                    |> Expect.equal (expected 30 [ 82.5, 45, 7.5 ])
+        ]
 
 
 interpolateTests : Test
@@ -63,16 +63,16 @@ interpolateTests =
         expected =
             expectedInterpolation domain
     in
-        describe "interpolate"
-            [ test "for inputs inside the domain" <|
-                \_ ->
-                    List.map (interpolate (createMapping 0 0) domain range) domain
-                        |> Expect.equal ((expected 40 [ 0, 40, 80 ]))
-            , test "for inputs not in the domain" <|
-                \_ ->
-                    interpolate (createMapping 0 0) domain range "d"
-                        |> Expect.equal ({ value = 0, width = 0, originalValue = "d" })
-            ]
+    describe "interpolate"
+        [ test "for inputs inside the domain" <|
+            \_ ->
+                List.map (interpolate (createMapping 0 0) domain range) domain
+                    |> Expect.equal (expected 40 [ 0, 40, 80 ])
+        , test "for inputs not in the domain" <|
+            \_ ->
+                interpolate (createMapping 0 0) domain range "d"
+                    |> Expect.equal { value = 0, width = 0, originalValue = "d" }
+        ]
 
 
 uninterpolateTests : Test
@@ -87,20 +87,20 @@ uninterpolateTests =
         expected =
             expectedInterpolation domain
     in
-        describe "uninterpolate"
-            [ test "for inputs that match excatly to a domain value" <|
-                \_ ->
-                    List.map (uninterpolate (createMapping 0 0) domain range) [ 0, 40, 80 ]
-                        |> Expect.equal (domain)
-            , test "for inputs that are close to a domain value" <|
-                \_ ->
-                    List.map (uninterpolate (createMapping 0 0) domain range) [ -1, 45, 95 ]
-                        |> Expect.equal (domain)
-            , test "for inputs that are exactly in between two domain values" <|
-                \_ ->
-                    uninterpolate (createMapping 0 0) domain range 20
-                        |> Expect.equal ("a")
-            ]
+    describe "uninterpolate"
+        [ test "for inputs that match excatly to a domain value" <|
+            \_ ->
+                List.map (uninterpolate (createMapping 0 0) domain range) [ 0, 40, 80 ]
+                    |> Expect.equal domain
+        , test "for inputs that are close to a domain value" <|
+            \_ ->
+                List.map (uninterpolate (createMapping 0 0) domain range) [ -1, 45, 95 ]
+                    |> Expect.equal domain
+        , test "for inputs that are exactly in between two domain values" <|
+            \_ ->
+                uninterpolate (createMapping 0 0) domain range 20
+                    |> Expect.equal "a"
+        ]
 
 
 ticksTests : Test
@@ -112,12 +112,12 @@ ticksTests =
         range =
             Interval.createFromTuple ( 0, 120 )
     in
-        describe "ticks"
-            [ test "it creates ticks for the given mapping in the middle of the bands" <|
-                \_ ->
-                    createTicks (createMapping 0 0) domain range
-                        |> Expect.equal ((expectedTicks [ 20, 60, 100 ] domain))
-            ]
+    describe "ticks"
+        [ test "it creates ticks for the given mapping in the middle of the bands" <|
+            \_ ->
+                createTicks (createMapping 0 0) domain range
+                    |> Expect.equal (expectedTicks [ 20, 60, 100 ] domain)
+        ]
 
 
 inDomainTests : Test
@@ -126,9 +126,9 @@ inDomainTests =
         [ test "for a value that is in the list of strings for the domain" <|
             \_ ->
                 inDomain [ "a" ] "a"
-                    |> Expect.equal (True)
+                    |> Expect.equal True
         , test "for a value that is not in the list of strings for the domain" <|
             \_ ->
                 inDomain [ "a" ] "b"
-                    |> Expect.equal (False)
+                    |> Expect.equal False
         ]

--- a/tests/Test/Private/Scale/UtilsTest.elm
+++ b/tests/Test/Private/Scale/UtilsTest.elm
@@ -1,11 +1,11 @@
 module Test.Private.Scale.UtilsTest exposing (..)
 
-import Private.Scale.Utils exposing (..)
-import Test exposing (..)
 import Expect
-import Test.TestUtils.Intervals exposing (assertInterval)
 import Private.BoundingBox as BoundingBox
 import Private.Extras.Interval as Interval
+import Private.Scale.Utils exposing (..)
+import Test exposing (..)
+import Test.TestUtils.Intervals exposing (assertInterval)
 
 
 tests : Test
@@ -35,37 +35,37 @@ calculateExtentTests =
         calculateExtent_ =
             calculateExtent boundingBox
     in
-        describe "calculateAxisExtent"
-            [ test "for the x axis and a range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ XScale interval
-            , test "for the y axis and a range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 10, 90 ) <|
-                        calculateExtent_ YScale interval
-            , test "for the x axis and a descending range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 90, 10 ) <|
-                        calculateExtent_ XScale descendingInterval
-            , test "for the y axis and a descending range fits inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 90, 10 ) <|
-                        calculateExtent_ YScale descendingInterval
-            , test "for the x axis and a range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 5, 95 ) <|
-                        calculateExtent_ XScale largeInterval
-            , test "for the y axis and a range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 2, 97 ) <|
-                        calculateExtent_ YScale largeInterval
-            , test "for the x axis and a descending range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 95, 5 ) <|
-                        calculateExtent_ XScale descendingLarge
-            , test "for the y axis and a descending range that does not inside the bounding box" <|
-                \_ ->
-                    assertInterval ( 97, 2 ) <|
-                        calculateExtent_ YScale descendingLarge
-            ]
+    describe "calculateAxisExtent"
+        [ test "for the x axis and a range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ XScale interval
+        , test "for the y axis and a range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 10, 90 ) <|
+                    calculateExtent_ YScale interval
+        , test "for the x axis and a descending range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 90, 10 ) <|
+                    calculateExtent_ XScale descendingInterval
+        , test "for the y axis and a descending range fits inside the bounding box" <|
+            \_ ->
+                assertInterval ( 90, 10 ) <|
+                    calculateExtent_ YScale descendingInterval
+        , test "for the x axis and a range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 5, 95 ) <|
+                    calculateExtent_ XScale largeInterval
+        , test "for the y axis and a range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 2, 97 ) <|
+                    calculateExtent_ YScale largeInterval
+        , test "for the x axis and a descending range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 95, 5 ) <|
+                    calculateExtent_ XScale descendingLarge
+        , test "for the y axis and a descending range that does not inside the bounding box" <|
+            \_ ->
+                assertInterval ( 97, 2 ) <|
+                    calculateExtent_ YScale descendingLarge
+        ]


### PR DESCRIPTION
As part of [AR-4343](https://indigobio.atlassian.net/browse/AR-4343) we want to move from using fixed width and height to using a viewbox so that chart automatically scales to the size of it's parent. 

But first, this repo has not been formatted with the latest elm-format so this PR makes those changes.